### PR TITLE
fix: change snapshot [WEB-1574]

### DIFF
--- a/src/queues/__tests__/__snapshots__/swapStatusCheck.test.ts.snap
+++ b/src/queues/__tests__/__snapshots__/swapStatusCheck.test.ts.snap
@@ -39,6 +39,24 @@ exports[`swapStatusCheck > check fresh swap status and send swap info message 1`
       },
       "name": "messageRouter",
     },
+    {
+      "data": {
+        "message": "🦐 Swap #77697
+📥 5000 FLIP ($5,568.07)
+📤 5616.094932 USDT ($5,611.38)
+⏱️ Took: 1 min
+🟢 Delta: $43.31 (0.77%)
+📓 Chunks: 2/2
+🏦 via Chainflip Swapping
+",
+        "platform": "twitter",
+        "validationData": {
+          "name": "NEW_SWAP",
+          "usdValue": 5611.3799573378,
+        },
+      },
+      "name": "messageRouter",
+    },
   ],
 ]
 `;


### PR DESCRIPTION
Change snapshot fron swapStatusCheck

Had  failed test in MainCI, because Snapshot `swapStatusCheck > check fresh swap status and send swap info message 1` mismatched.