### PR TITLE
fix: handle no egress

### DIFF
--- a/src/queries/__tests__/swapInfo.json
+++ b/src/queries/__tests__/swapInfo.json
@@ -8,7 +8,11 @@
       "egress": {
         "amount": "5616094932",
         "valueUsd": "5611.379957337800000000000000000000",
-        "scheduledEvent": { "block": { "timestamp": "2024-10-25T12:41:30+00:00" } }
+        "scheduledEvent": {
+          "block": {
+            "timestamp": "2024-10-25T12:41:30+00:00"
+          }
+        }
       },
       "swapChannel": {
         "broker": {
@@ -20,10 +24,20 @@
         "fokMinPriceX128": "370463044445583550774471879",
         "issuedBlockTimestamp": "2024-10-25T12:39:06+00:00"
       },
-      "preDepositBlock": { "stateChainTimestamp": "2024-10-25T12:39:30+00:00" },
-      "depositBlock": { "stateChainTimestamp": "2024-10-25T12:39:42+00:00" },
-      "completedEvent": { "block": { "timestamp": "2024-10-25T12:41:30+00:00" } },
-      "executedSwaps": { "totalCount": 2 },
+      "preDepositBlock": {
+        "stateChainTimestamp": "2024-10-25T12:39:30+00:00"
+      },
+      "depositBlock": {
+        "stateChainTimestamp": "2024-10-25T12:39:42+00:00"
+      },
+      "completedEvent": {
+        "block": {
+          "timestamp": "2024-10-25T12:41:30+00:00"
+        }
+      },
+      "executedSwaps": {
+        "totalCount": 2
+      },
       "fees": {
         "nodes": [
           {
@@ -112,6 +126,64 @@
           {
             "valueUsd": "3.586942343400000000000000000000",
             "amount": "1238145411790000",
+            "asset": "Eth",
+            "type": "EGRESS"
+          }
+        ]
+      }
+    }
+  },
+  "103706": {
+    "swap": {
+      "completedEventId": "5459228833",
+      "nativeId": "103706",
+      "depositAmount": "10000000000000000",
+      "depositValueUsd": "29.347510448600000000000000000000",
+      "sourceChain": "Ethereum",
+      "numberOfChunks": null,
+      "destinationAsset": "Btc",
+      "sourceAsset": "Eth",
+      "effectiveBoostFeeBps": null,
+      "egress": null,
+      "refundEgress": {
+        "amount": "7514850381540000",
+        "valueUsd": "22.097080603800000000000000000000"
+      },
+      "swapChannel": {
+        "broker": {
+          "account": {
+            "alias": "Chainflip Swapping",
+            "idSs58": "cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7"
+          }
+        },
+        "fokMinPriceX128": "1324305130782670656152882420",
+        "issuedBlockTimestamp": "2024-11-08T12:38:12+00:00"
+      },
+      "preDepositBlock": {
+        "stateChainTimestamp": "2024-11-08T12:52:06+00:00"
+      },
+      "depositBlock": {
+        "stateChainTimestamp": "2024-11-08T12:52:18+00:00"
+      },
+      "completedEvent": {
+        "block": {
+          "timestamp": "2024-11-08T13:08:42+00:00"
+        }
+      },
+      "executedSwaps": {
+        "totalCount": 0
+      },
+      "fees": {
+        "nodes": [
+          {
+            "valueUsd": "3.182866212800000000000000000000",
+            "amount": "1084543855400000",
+            "asset": "Eth",
+            "type": "INGRESS"
+          },
+          {
+            "valueUsd": "4.118418447400000000000000000000",
+            "amount": "1400605763060000",
             "asset": "Eth",
             "type": "EGRESS"
           }

--- a/src/queries/__tests__/swapInfo.test.ts
+++ b/src/queries/__tests__/swapInfo.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { describe, it, vi, expect } from 'vitest';
 import getSwapInfo from '../getSwapInfo.js';
 import swapInfoStats from './swapInfo.json' with { type: 'json' };
@@ -6,10 +7,8 @@ import { explorerClient } from '../../server.js';
 
 describe('swapInfo', () => {
   it('gets the swap info by nativeId', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    vi.mocked(explorerClient.request).mockResolvedValue(swapInfoStats['77697']);
-
     const nativeId = '77697';
+    vi.mocked(explorerClient.request).mockResolvedValue(swapInfoStats[nativeId]);
     expect(await getSwapInfo(nativeId)).toMatchInlineSnapshot(`
       {
         "boostFee": undefined,
@@ -20,21 +19,19 @@ describe('swapInfo', () => {
         "completedAt": "2024-10-25T12:41:30+00:00",
         "completedEventId": "5116679443",
         "dcaChunks": "2/2",
-        "depositAmount": "5,000",
-        "depositValueUsd": "5568.071581114500000000000000000000",
+        "depositAmount": "5000",
+        "depositValueUsd": "5568.0715811145",
         "destinationAsset": "Usdt",
         "duration": "1 min",
-        "effectiveBoostFeeBps": null,
-        "egressAmount": "5,616.094932",
-        "egressValueUsd": "5611.379957337800000000000000000000",
+        "egressAmount": "5616.094932",
+        "egressValueUsd": "5611.3799573378",
         "minPrice": "1.088693",
-        "originalDepositAmount": "5,000",
+        "originalDepositAmount": "5000",
         "originalDepositValueUsd": "5568.071581114500000000000000000000",
-        "partiallyRefunded": false,
         "priceDelta": 43.3083762233,
-        "priceDeltaPercentage": "0.77",
-        "refundAmount": undefined,
-        "refundValueUsd": undefined,
+        "priceDeltaPercentage": "0.78",
+        "refundAmount": null,
+        "refundValueUsd": null,
         "requestId": "77697",
         "sourceAsset": "Flip",
       }
@@ -53,7 +50,7 @@ describe('swapInfo', () => {
     expect(await getSwapInfo(nativeId)).toMatchInlineSnapshot(`
       {
         "boostFee": {
-          "valueUsd": 0.2167859022,
+          "valueUsd": "0.2167859022",
         },
         "brokerIdAndAlias": {
           "alias": "Chainflip Swapping",
@@ -63,22 +60,56 @@ describe('swapInfo', () => {
         "completedEventId": "5377221676",
         "dcaChunks": undefined,
         "depositAmount": "0.0063",
-        "depositValueUsd": "433.571804422900000000000000000000",
+        "depositValueUsd": "433.5718044229",
         "destinationAsset": "Eth",
         "duration": "9 min",
-        "effectiveBoostFeeBps": 5,
-        "egressAmount": "0.177273",
-        "egressValueUsd": "432.311738749600000000000000000000",
+        "egressAmount": "0.177273354596517176",
+        "egressValueUsd": "432.3117387496",
         "minPrice": "28.027233685216537779",
         "originalDepositAmount": "0.0063",
         "originalDepositValueUsd": "433.571804422900000000000000000000",
-        "partiallyRefunded": false,
         "priceDelta": -1.260065673300005,
-        "priceDeltaPercentage": "-0.36",
-        "refundAmount": undefined,
-        "refundValueUsd": undefined,
+        "priceDeltaPercentage": "-0.29",
+        "refundAmount": null,
+        "refundValueUsd": null,
         "requestId": "98822",
         "sourceAsset": "Btc",
+      }
+    `);
+
+    expect(explorerClient.request).toHaveBeenCalledWith(expect.anything(), {
+      nativeId,
+    });
+  });
+
+  it('gets info about a fully refunded swap', async () => {
+    const nativeId = '103706';
+    vi.mocked(explorerClient.request).mockResolvedValue(swapInfoStats[nativeId]);
+    expect(await getSwapInfo(nativeId)).toMatchInlineSnapshot(`
+      {
+        "boostFee": undefined,
+        "brokerIdAndAlias": {
+          "alias": "Chainflip Swapping",
+          "brokerId": "cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7",
+        },
+        "completedAt": "2024-11-08T13:08:42+00:00",
+        "completedEventId": "5459228833",
+        "dcaChunks": undefined,
+        "depositAmount": "0.00248514961846",
+        "depositValueUsd": "7.2932954394089153441156",
+        "destinationAsset": "Btc",
+        "duration": undefined,
+        "egressAmount": null,
+        "egressValueUsd": null,
+        "minPrice": "0.03891783",
+        "originalDepositAmount": "0.01",
+        "originalDepositValueUsd": "29.347510448600000000000000000000",
+        "priceDelta": null,
+        "priceDeltaPercentage": null,
+        "refundAmount": "0.00751485038154",
+        "refundValueUsd": "22.0970806038",
+        "requestId": "103706",
+        "sourceAsset": "Eth",
       }
     `);
 

--- a/src/queues/__tests__/__snapshots__/swapStatusCheck.test.ts.snap
+++ b/src/queues/__tests__/__snapshots__/swapStatusCheck.test.ts.snap
@@ -13,7 +13,7 @@ exports[`swapStatusCheck > check fresh swap status and send swap info message 1`
 📥 <strong>5,000 FLIP on Ethereum</strong> ($5,568.07)
 📤 <strong>5,616.094932 USDT on Ethereum</strong> ($5,611.38)
 ⏱️ Took: <strong>1 min</strong>
-🟢 Delta: <strong>$43.31</strong> (0.77%)
+🟢 Delta: <strong>$43.31</strong> (0.78%)
 📓 Chunks: <strong>2/2</strong>
 🏦 via <strong><a href="https://scan.chainflip.io/brokers/cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7">Chainflip Swapping</a></strong>",
         "platform": "telegram",
@@ -30,7 +30,7 @@ exports[`swapStatusCheck > check fresh swap status and send swap info message 1`
 📥 **5,000 FLIP on Ethereum** ($5,568.07)
 📤 **5,616.094932 USDT on Ethereum** ($5,611.38)
 ⏱️ Took: **1 min**
-🟢 Delta: **$43.31** (0.77%)
+🟢 Delta: **$43.31** (0.78%)
 📓 Chunks: **2/2**
 🏦 via **[Chainflip Swapping](https://scan.chainflip.io/brokers/cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7)**",
         "platform": "discord",
@@ -47,7 +47,7 @@ exports[`swapStatusCheck > check fresh swap status and send swap info message 1`
 📥 5,000 FLIP on Ethereum ($5,568.07)
 📤 5,616.094932 USDT on Ethereum ($5,611.38)
 ⏱️ Took: 1 min
-🟢 Delta: $43.31 (0.77%)
+🟢 Delta: $43.31 (0.78%)
 📓 Chunks: 2/2
 🏦 via Chainflip Swapping",
         "platform": "twitter",
@@ -72,7 +72,7 @@ exports[`swapStatusCheck > subtracts out the refund egress amount from the ingre
 📤 <strong>5.939236 ETH on Ethereum</strong> ($17,206.14)
 ↩️ <strong>24,455.099318 FLIP on Ethereum</strong> ($31,269.46)
 ⏱️ Took: <strong>18 min</strong>
-🟢 Delta: <strong>$167.20</strong> (0.98%)
+🟢 Delta: <strong>$167.19</strong> (0.98%)
 📓 Chunks: <strong>6/17</strong>
 🏦 via <strong><a href="https://scan.chainflip.io/brokers/cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7">Chainflip Swapping</a></strong>",
         "platform": "telegram",
@@ -90,7 +90,7 @@ exports[`swapStatusCheck > subtracts out the refund egress amount from the ingre
 📤 **5.939236 ETH on Ethereum** ($17,206.14)
 ↩️ **24,455.099318 FLIP on Ethereum** ($31,269.46)
 ⏱️ Took: **18 min**
-🟢 Delta: **$167.20** (0.98%)
+🟢 Delta: **$167.19** (0.98%)
 📓 Chunks: **6/17**
 🏦 via **[Chainflip Swapping](https://scan.chainflip.io/brokers/cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7)**",
         "platform": "discord",
@@ -108,7 +108,7 @@ exports[`swapStatusCheck > subtracts out the refund egress amount from the ingre
 📤 5.939236 ETH on Ethereum ($17,206.14)
 ↩️ 24,455.099318 FLIP on Ethereum ($31,269.46)
 ⏱️ Took: 18 min
-🟢 Delta: $167.20 (0.98%)
+🟢 Delta: $167.19 (0.98%)
 📓 Chunks: 6/17
 🏦 via Chainflip Swapping",
         "platform": "twitter",

--- a/src/queues/__tests__/swapStatusCheck.test.ts
+++ b/src/queues/__tests__/swapStatusCheck.test.ts
@@ -93,4 +93,19 @@ describe('swapStatusCheck', () => {
 
     expect(dispatchJobs.mock.lastCall).toMatchSnapshot();
   });
+
+  it('ignores fully refunded swaps', async () => {
+    const swapRequestId = '103706';
+    vi.setSystemTime(new Date(swapInfoStats[swapRequestId].swap.completedEvent.block.timestamp));
+    vi.mocked(explorerClient.request).mockResolvedValue(swapInfoStats[swapRequestId]);
+
+    const dispatchJobs = vi.fn();
+    await config.processJob(dispatchJobs)({
+      data: {
+        swapRequestId,
+      } as JobData['swapStatusCheck'],
+    } as any);
+
+    expect(dispatchJobs).not.toHaveBeenCalled();
+  });
 });

--- a/src/queues/swapStatusCheck.tsx
+++ b/src/queues/swapStatusCheck.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BigNumber } from 'bignumber.js';
 import { differenceInMinutes } from 'date-fns';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { DispatchJobArgs, JobConfig, JobProcessor } from './initialize.js';
@@ -6,7 +7,9 @@ import { Bold, ExplorerLink, Line } from '../channels/formatting.js';
 import { platforms } from '../config.js';
 import { humanFriendlyAsset } from '../consts.js';
 import env from '../env.js';
+import { ChainflipAsset } from '../graphql/generated/graphql.js';
 import getSwapInfo from '../queries/getSwapInfo.js';
+import { toFormattedAmount } from '../utils/chainflip.js';
 import logger from '../utils/logger.js';
 import { formatUsdValue } from '../utils/strings.js';
 
@@ -61,11 +64,17 @@ const deltaSign = (delta: number) => {
   return '🟢';
 };
 
-const UsdValue = ({ amount }: { amount: string | null | undefined }): React.JSX.Element | null => {
+const UsdValue = ({ amount }: { amount: BigNumber | null }): React.JSX.Element | null => {
   if (!amount) return null;
 
   return <> ({formatUsdValue(amount)})</>;
 };
+
+const TokenAmount = ({ amount, asset }: { amount: BigNumber; asset: ChainflipAsset }) => (
+  <>
+    {toFormattedAmount(amount)} {humanFriendlyAsset[asset]}
+  </>
+);
 
 const buildMessageData = ({
   swapInfo,
@@ -86,7 +95,7 @@ const buildMessageData = ({
         <Line>
           📥{' '}
           <Bold platform={platform}>
-            {swapInfo.depositAmount} {humanFriendlyAsset[swapInfo.sourceAsset]}
+            <TokenAmount amount={swapInfo.depositAmount} asset={swapInfo.sourceAsset} />
           </Bold>
           <UsdValue amount={swapInfo.depositValueUsd} />
         </Line>
@@ -94,7 +103,7 @@ const buildMessageData = ({
           <Line>
             📤{' '}
             <Bold platform={platform}>
-              {swapInfo.egressAmount} {humanFriendlyAsset[swapInfo.destinationAsset]}
+              <TokenAmount amount={swapInfo.egressAmount} asset={swapInfo.destinationAsset} />
             </Bold>
             <UsdValue amount={swapInfo.egressValueUsd} />
           </Line>
@@ -103,7 +112,7 @@ const buildMessageData = ({
           <Line>
             ↩️{' '}
             <Bold platform={platform}>
-              {swapInfo.refundAmount} {humanFriendlyAsset[swapInfo.sourceAsset]}
+              <TokenAmount amount={swapInfo.refundAmount} asset={swapInfo.sourceAsset} />
             </Bold>
             <UsdValue amount={swapInfo.refundValueUsd} />
           </Line>
@@ -113,7 +122,7 @@ const buildMessageData = ({
             ⏱️ Took: <Bold platform={platform}>{swapInfo.duration}</Bold>
           </Line>
         )}
-        {swapInfo.priceDelta && swapInfo.priceDeltaPercentage && (
+        {swapInfo.priceDelta !== null && swapInfo.priceDeltaPercentage && (
           <Line>
             {deltaSign(Number(swapInfo.priceDeltaPercentage))} Delta:{' '}
             <Bold platform={platform}>
@@ -130,9 +139,9 @@ const buildMessageData = ({
             📓 Chunks: <Bold platform={platform}>{swapInfo.dcaChunks}</Bold>
           </Line>
         )}
-        {swapInfo.effectiveBoostFeeBps && swapInfo.boostFee && (
+        {swapInfo.boostFee?.valueUsd && (
           <Line>
-            ⚡ <Bold platform={platform}>Boosted </Bold> for{' '}
+            ⚡ <Bold platform={platform}>Boosted</Bold> for{' '}
             <Bold platform={platform}>{formatUsdValue(swapInfo.boostFee.valueUsd)}</Bold>
           </Line>
         )}
@@ -169,7 +178,10 @@ const processJob: JobProcessor<Name> = (dispatchJobs) => async (job) => {
 
   const jobs = [] as DispatchJobArgs[];
 
-  if (swapInfo.completedEventId && Number(swapInfo.egressAmount) === 0) {
+  if (
+    swapInfo.completedEventId &&
+    (swapInfo.egressAmount === null || swapInfo.egressAmount.isZero())
+  ) {
     logger.info(`Swap egress amount is zero, so it was refunded`);
     return;
   }

--- a/src/utils/chainflip.ts
+++ b/src/utils/chainflip.ts
@@ -23,8 +23,25 @@ export const chainConstants = {
 
 export type ChainflipChain = 'Bitcoin' | 'Ethereum' | 'Solana' | 'Arbitrum' | 'Polkadot';
 
-export const toAssetAmount = (amount: string, chainflipAsset: ChainflipAsset): BigNumber =>
-  new BigNumber(amount).shiftedBy(-assetDecimals[chainflipAsset]);
+export function toUsdAmount(amount: BigNumber.Value): BigNumber;
+export function toUsdAmount(amount: BigNumber.Value | null | undefined): BigNumber | null;
+export function toUsdAmount(amount: BigNumber.Value | null | undefined): BigNumber | null {
+  if (amount == null) return null;
+  return new BigNumber(amount);
+}
+
+export function toAssetAmount(amount: BigNumber.Value, chainflipAsset: ChainflipAsset): BigNumber;
+export function toAssetAmount(
+  amount: BigNumber.Value | null | undefined,
+  chainflipAsset: ChainflipAsset,
+): BigNumber | null;
+export function toAssetAmount(
+  amount: BigNumber.Value | null | undefined,
+  chainflipAsset: ChainflipAsset,
+): BigNumber | null {
+  if (amount == null) return null;
+  return new BigNumber(amount).shiftedBy(-assetDecimals[chainflipAsset]);
+}
 
 export function toFormattedAmount(amount: BigNumber): string;
 export function toFormattedAmount(amount: string, chainflipAsset: ChainflipAsset): string;


### PR DESCRIPTION
The fully refunded swap was checking `Number(egressAmount) === 0` but at some point I changed the `egressAmount` to be a formatted string, but it could also be `null | undefined`, so this turned into `NaN === 0` in every case and was therefore always false.

I restructured `getSwapInfo` to always return `BigNumber | null` for USD values and token amounts