### PR TITLE
fix: remove unnecessary sort

### DIFF
--- a/src/__mocks__/__fixtures__/GetAccount-7c2174/5d26cb.json
+++ b/src/__mocks__/__fixtures__/GetAccount-7c2174/5d26cb.json
@@ -1,0 +1,82 @@
+{
+  "accounts": {
+    "nodes": [
+      {
+        "id": 2,
+        "idSs58": "cFNzKSS48cZ1xQmdub2ykc2LUc5UZS2YjLaZBUvmxoXHjMMVh"
+      },
+      {
+        "id": 3,
+        "idSs58": "cFJXT4WEEdfiShje4z9JMwAvMiMTu7nioPgXsE9o1KqdVrzLg"
+      },
+      {
+        "id": 7,
+        "idSs58": "cFLGvPhhrribWCx9id5kLVqwiFK4QiVNjQ6ViyaRFF2Nrgq7j"
+      },
+      {
+        "id": 9,
+        "idSs58": "cFKZarxpf9MVwzzmYUtQfV61PRkYgTj9wUgUCeuKpKgMLrTow"
+      },
+      {
+        "id": 27,
+        "idSs58": "cFLBKavxvThwqLWNr7cTwtqhYD6jDqXM31d6QoTLvuK4X78ve"
+      },
+      {
+        "id": 34,
+        "idSs58": "cFK6qCSmgYJACMNVk6JnCb5nkccr7yM6aZiKtXUnFAzsX7hvs"
+      },
+      {
+        "id": 36,
+        "idSs58": "cFKy4xbhLxvAVxYuPEWbbTJTed5WtyqNVikH2fS2WYLNHRrFh"
+      },
+      {
+        "id": 50,
+        "idSs58": "cFJtLQCKAGqSpamy1R9W4efQHaq5PhKSK93ucVRZMJq6ute8F"
+      },
+      {
+        "id": 53,
+        "idSs58": "cFPV6R6vXWAXVityn3XAZNMQDkuZ96LcmS2euYYrGjchWWAri"
+      },
+      {
+        "id": 56,
+        "idSs58": "cFPJNbXH9KNP1CRejnf19ARopcS8w8c4teTz5GF3G36MZRWJG"
+      },
+      {
+        "id": 57,
+        "idSs58": "cFNgY2xnF9jvLLJ9TTtFwVTUCoo9aAX26UveiN7NftzkhEyYW"
+      },
+      {
+        "id": 70,
+        "idSs58": "cFMVQrUbuTuXmeRinPQovRkCgoyrrRd3N4Q5ZdHfqv4VJi5Hh"
+      },
+      {
+        "id": 79,
+        "idSs58": "cFNyp1zp93cBrHnsPjSpgc2JGwGmiQbtrrTNRNeZteRkb3Ud4"
+      },
+      {
+        "id": 103,
+        "idSs58": "cFHw1UHP69RiSSj5FSYRx5e4Fuh4qg4625zBxW2XbE4wK6JTL"
+      },
+      {
+        "id": 109,
+        "idSs58": "cFJYzUFU97Y849kbKvyj7br1CUumnbqWHJKDcfPFoKRqq6Zxz"
+      },
+      {
+        "id": 118,
+        "idSs58": "cFMTFP2F61oRQGf7rUZpD2gaNtEjH65Sm6xhay4xmgBcwD26a"
+      },
+      {
+        "id": 131,
+        "idSs58": "cFNAnhKPq7hnCKBM2rgo7v7WyroRsZiKm9gKSoPcggdyfYwaA"
+      },
+      {
+        "id": 153,
+        "idSs58": "cFPQQaEEGnzuZTBg8S3JuhiTu1CTrHXDzKAZfvNrSrjUUQQ1z"
+      },
+      {
+        "id": 155,
+        "idSs58": "cFLZS9GDX4CeXWdjqm2sXmVUNqW1H71BK5nfUXHo6qtKDqNHu"
+      }
+    ]
+  }
+}

--- a/src/queries/__tests__/lpFills.test.ts
+++ b/src/queries/__tests__/lpFills.test.ts
@@ -23,7 +23,7 @@ describe('getLpFills', () => {
         {
           "alias": "Selini",
           "filledAmountValueUsd": "9434345.0577949431",
-          "idSs58": "cFKZarxpf9MVwzzmYUtQfV61PRkYgTj9wUgUCeuKpKgMLrTow",
+          "idSs58": "cFLGvPhhrribWCx9id5kLVqwiFK4QiVNjQ6ViyaRFF2Nrgq7j",
           "percentage": "15.70",
         },
         {
@@ -47,7 +47,7 @@ describe('getLpFills', () => {
         {
           "alias": "curiouspleb",
           "filledAmountValueUsd": "673831.4974354201",
-          "idSs58": "cFNgY2xnF9jvLLJ9TTtFwVTUCoo9aAX26UveiN7NftzkhEyYW",
+          "idSs58": "cFPJNbXH9KNP1CRejnf19ARopcS8w8c4teTz5GF3G36MZRWJG",
           "percentage": "1.12",
         },
         {


### PR DESCRIPTION
Fixing tech debt from #124 

While running `pnpm dev` and `pnpm test`, the file `src/__mocks__/__fixtures__/GetAccount-7c2174/5d26cb.json` was created in my local env, but I didn't commit it. It seems to be a full copy of `src/__mocks__/__fixtures__/GetAccount-7c2174/169171.json` (which is tracked on the repo). Let me know if you need me to push it.

The content of the file is:

```json
{
  "accounts": {
    "nodes": [
      {
        "id": 2,
        "idSs58": "cFNzKSS48cZ1xQmdub2ykc2LUc5UZS2YjLaZBUvmxoXHjMMVh"
      },
      {
        "id": 3,
        "idSs58": "cFJXT4WEEdfiShje4z9JMwAvMiMTu7nioPgXsE9o1KqdVrzLg"
      },
      {
        "id": 7,
        "idSs58": "cFLGvPhhrribWCx9id5kLVqwiFK4QiVNjQ6ViyaRFF2Nrgq7j"
      },
      {
        "id": 9,
        "idSs58": "cFKZarxpf9MVwzzmYUtQfV61PRkYgTj9wUgUCeuKpKgMLrTow"
      },
      {
        "id": 27,
        "idSs58": "cFLBKavxvThwqLWNr7cTwtqhYD6jDqXM31d6QoTLvuK4X78ve"
      },
      {
        "id": 34,
        "idSs58": "cFK6qCSmgYJACMNVk6JnCb5nkccr7yM6aZiKtXUnFAzsX7hvs"
      },
      {
        "id": 36,
        "idSs58": "cFKy4xbhLxvAVxYuPEWbbTJTed5WtyqNVikH2fS2WYLNHRrFh"
      },
      {
        "id": 50,
        "idSs58": "cFJtLQCKAGqSpamy1R9W4efQHaq5PhKSK93ucVRZMJq6ute8F"
      },
      {
        "id": 53,
        "idSs58": "cFPV6R6vXWAXVityn3XAZNMQDkuZ96LcmS2euYYrGjchWWAri"
      },
      {
        "id": 56,
        "idSs58": "cFPJNbXH9KNP1CRejnf19ARopcS8w8c4teTz5GF3G36MZRWJG"
      },
      {
        "id": 57,
        "idSs58": "cFNgY2xnF9jvLLJ9TTtFwVTUCoo9aAX26UveiN7NftzkhEyYW"
      },
      {
        "id": 70,
        "idSs58": "cFMVQrUbuTuXmeRinPQovRkCgoyrrRd3N4Q5ZdHfqv4VJi5Hh"
      },
      {
        "id": 79,
        "idSs58": "cFNyp1zp93cBrHnsPjSpgc2JGwGmiQbtrrTNRNeZteRkb3Ud4"
      },
      {
        "id": 103,
        "idSs58": "cFHw1UHP69RiSSj5FSYRx5e4Fuh4qg4625zBxW2XbE4wK6JTL"
      },
      {
        "id": 109,
        "idSs58": "cFJYzUFU97Y849kbKvyj7br1CUumnbqWHJKDcfPFoKRqq6Zxz"
      },
      {
        "id": 118,
        "idSs58": "cFMTFP2F61oRQGf7rUZpD2gaNtEjH65Sm6xhay4xmgBcwD26a"
      },
      {
        "id": 131,
        "idSs58": "cFNAnhKPq7hnCKBM2rgo7v7WyroRsZiKm9gKSoPcggdyfYwaA"
      },
      {
        "id": 153,
        "idSs58": "cFPQQaEEGnzuZTBg8S3JuhiTu1CTrHXDzKAZfvNrSrjUUQQ1z"
      },
      {
        "id": 155,
        "idSs58": "cFLZS9GDX4CeXWdjqm2sXmVUNqW1H71BK5nfUXHo6qtKDqNHu"
      }
    ]
  }
}
```