### PR TITLE
chore: add lending constraints for min usd value

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -198,6 +198,51 @@ describe('Config', () => {
         ),
       ).toBe(true);
     });
+
+    it('works with NEW_BORROW', () => {
+      expect(
+        Config.canSend(
+          { key: 'discord:1234', filters: [{ name: 'NEW_BORROW', minUsdValue: 100 }] },
+          { name: 'NEW_BORROW', usdValue: 50 },
+        ),
+      ).toBe(false);
+      expect(
+        Config.canSend(
+          { key: 'discord:1234', filters: [{ name: 'NEW_BORROW', minUsdValue: 100 }] },
+          { name: 'NEW_BORROW', usdValue: 150 },
+        ),
+      ).toBe(true);
+    });
+
+    it('works with NEW_REPAYMENT', () => {
+      expect(
+        Config.canSend(
+          { key: 'discord:1234', filters: [{ name: 'NEW_REPAYMENT', minUsdValue: 100 }] },
+          { name: 'NEW_REPAYMENT', usdValue: 50 },
+        ),
+      ).toBe(false);
+      expect(
+        Config.canSend(
+          { key: 'discord:1234', filters: [{ name: 'NEW_REPAYMENT', minUsdValue: 100 }] },
+          { name: 'NEW_REPAYMENT', usdValue: 150 },
+        ),
+      ).toBe(true);
+    });
+
+    it('works with NEW_DEPOSIT', () => {
+      expect(
+        Config.canSend(
+          { key: 'discord:1234', filters: [{ name: 'NEW_DEPOSIT', minUsdValue: 100 }] },
+          { name: 'NEW_DEPOSIT', usdValue: 50 },
+        ),
+      ).toBe(false);
+      expect(
+        Config.canSend(
+          { key: 'discord:1234', filters: [{ name: 'NEW_DEPOSIT', minUsdValue: 100 }] },
+          { name: 'NEW_DEPOSIT', usdValue: 150 },
+        ),
+      ).toBe(true);
+    });
   });
 
   describe('Config.load', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,9 +18,9 @@ const filters = z.discriminatedUnion('name', [
   z.object({ name: z.literal('NEW_BURN') }),
   z.object({ name: z.literal('NEW_LP') }),
   z.object({ name: z.literal('DELEGATION_EVENT') }),
-  z.object({ name: z.literal('NEW_BORROW') }),
-  z.object({ name: z.literal('NEW_REPAYMENT') }),
-  z.object({ name: z.literal('NEW_DEPOSIT') }),
+  z.object({ name: z.literal('NEW_BORROW'), minUsdValue: z.number().optional().default(0) }),
+  z.object({ name: z.literal('NEW_REPAYMENT'), minUsdValue: z.number().optional().default(0) }),
+  z.object({ name: z.literal('NEW_DEPOSIT'), minUsdValue: z.number().optional().default(0) }),
   z.object({ name: z.literal('NEW_WITHDRAWAL') }),
   z.object({ name: z.literal('LIQUIDATION_INITIATED') }),
   z.object({ name: z.literal('LIQUIDATION_COMPLETED') }),
@@ -30,7 +30,10 @@ export type Filter = z.infer<typeof filters>;
 
 export type FilterData =
   | Exclude<Filter, { name: Extract<Filter, { minUsdValue: number }>['name'] }>
-  | { name: 'SWAP_COMPLETED' | 'NEW_SWAP'; usdValue: number };
+  | {
+      name: 'SWAP_COMPLETED' | 'NEW_SWAP' | 'NEW_BORROW' | 'NEW_REPAYMENT' | 'NEW_DEPOSIT';
+      usdValue: number;
+    };
 
 const specializedMessages: Filter['name'][] = ['NEW_SWAP'];
 
@@ -198,7 +201,13 @@ export default class Config {
   static canSend(channel: Channel, filterData: FilterData): boolean {
     if (channel.filters === undefined) return !specializedMessages.includes(filterData.name);
 
-    if (filterData.name === 'SWAP_COMPLETED' || filterData.name === 'NEW_SWAP') {
+    if (
+      filterData.name === 'SWAP_COMPLETED' ||
+      filterData.name === 'NEW_SWAP' ||
+      filterData.name === 'NEW_BORROW' ||
+      filterData.name === 'NEW_REPAYMENT' ||
+      filterData.name === 'NEW_DEPOSIT'
+    ) {
       const filter = channel.filters.find((rule) => rule.name === filterData.name) as
         | Extract<Filter, { name: (typeof filterData)['name'] }>
         | undefined;

--- a/src/queues/__tests__/newLendingLiquidityChangeCheck.test.ts
+++ b/src/queues/__tests__/newLendingLiquidityChangeCheck.test.ts
@@ -78,6 +78,7 @@ describe('newLendingLiquidityChangeCheck', () => {
                 "data": {
                   "filterData": {
                     "name": "NEW_DEPOSIT",
+                    "usdValue": 128.2652526243,
                   },
                   "message": "🏦 Lending pool transaction
         👤 Account: <strong><a href="https://scan.chainflip.io/lps/cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7">cFLRQDfE…D2ENbqj7</a></strong>
@@ -91,6 +92,7 @@ describe('newLendingLiquidityChangeCheck', () => {
                 "data": {
                   "filterData": {
                     "name": "NEW_DEPOSIT",
+                    "usdValue": 128.2652526243,
                   },
                   "message": "🏦 Lending pool transaction
         👤 Account: **[cFLRQDfE…D2ENbqj7](https://scan.chainflip.io/lps/cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7)**
@@ -104,6 +106,7 @@ describe('newLendingLiquidityChangeCheck', () => {
                 "data": {
                   "filterData": {
                     "name": "NEW_DEPOSIT",
+                    "usdValue": 128.2652526243,
                   },
                   "message": "🏦 Lending pool transaction
         👤 Account: https://scan.chainflip.io/lps/cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7
@@ -163,6 +166,7 @@ describe('newLendingLiquidityChangeCheck', () => {
                 "data": {
                   "filterData": {
                     "name": "NEW_DEPOSIT",
+                    "usdValue": 128.2652526243,
                   },
                   "message": "🏦 Lending pool transaction
         💳 Type: <strong>Supply</strong>
@@ -175,6 +179,7 @@ describe('newLendingLiquidityChangeCheck', () => {
                 "data": {
                   "filterData": {
                     "name": "NEW_DEPOSIT",
+                    "usdValue": 128.2652526243,
                   },
                   "message": "🏦 Lending pool transaction
         💳 Type: **Supply**
@@ -187,6 +192,7 @@ describe('newLendingLiquidityChangeCheck', () => {
                 "data": {
                   "filterData": {
                     "name": "NEW_DEPOSIT",
+                    "usdValue": 128.2652526243,
                   },
                   "message": "🏦 Lending pool transaction
         💳 Type: Supply

--- a/src/queues/__tests__/newLoanUpdateCheck.test.ts
+++ b/src/queues/__tests__/newLoanUpdateCheck.test.ts
@@ -71,6 +71,7 @@ describe('newLoanUpdateCheck', () => {
                 "data": {
                   "filterData": {
                     "name": "NEW_BORROW",
+                    "usdValue": 128.2652526243,
                   },
                   "message": "🏦 Loan <strong><a href="https://scan.chainflip.io/loans/3">#3</a></strong>
         👤 Account: <strong><a href="https://scan.chainflip.io/lps/cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7">cFLRQDfE…D2ENbqj7</a></strong>
@@ -84,6 +85,7 @@ describe('newLoanUpdateCheck', () => {
                 "data": {
                   "filterData": {
                     "name": "NEW_BORROW",
+                    "usdValue": 128.2652526243,
                   },
                   "message": "🏦 Loan **[#3](https://scan.chainflip.io/loans/3)**
         👤 Account: **[cFLRQDfE…D2ENbqj7](https://scan.chainflip.io/lps/cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7)**
@@ -97,6 +99,7 @@ describe('newLoanUpdateCheck', () => {
                 "data": {
                   "filterData": {
                     "name": "NEW_BORROW",
+                    "usdValue": 128.2652526243,
                   },
                   "message": "🏦 Loan https://scan.chainflip.io/loans/3
         👤 Account: https://scan.chainflip.io/lps/cFLRQDfEdmnv6d2XfHJNRBQHi4fruPMReLSfvB8WWD2ENbqj7

--- a/src/queues/newLendingLiquidityChangeCheck.tsx
+++ b/src/queues/newLendingLiquidityChangeCheck.tsx
@@ -102,7 +102,7 @@ const buildMessages = ({
           <Trailer />
         </>,
       ).trimEnd(),
-      filterData: { name: filterName },
+      filterData: { name: filterName, usdValue: amountValueUsd?.toNumber() || 0 },
     },
   }));
 };

--- a/src/queues/newLoanUpdateCheck.tsx
+++ b/src/queues/newLoanUpdateCheck.tsx
@@ -106,7 +106,7 @@ const buildMessages = ({
           <Trailer />
         </>,
       ).trimEnd(),
-      filterData: { name: filterName },
+      filterData: { name: filterName, usdValue: amountValueUsd.toNumber() },
     },
   }));
 };


### PR DESCRIPTION
Adds constraints for min USD value in lending transaction messages.

Validate USD value of transaction for `'NEW_BORROW'`, `'NEW_REPAYMENT'`, `'NEW_DEPOSIT'` filter names.