### PR TITLE
feat: clarify chain labels in swap copy

### DIFF
--- a/src/banners/assetRegistry.ts
+++ b/src/banners/assetRegistry.ts
@@ -26,8 +26,18 @@ const token = (name: string) => ({
 
 export const ASSET_REGISTRY: InternalAssetMap<AssetMeta> = {
   ArbEth: { symbol: 'ETH', displayName: 'ETH', ...token('eth'), chainBadgePath: arbChain },
-  ArbUsdc: { symbol: 'USDC', displayName: 'USDC.arb', ...token('usdc'), chainBadgePath: arbChain },
-  ArbUsdt: { symbol: 'USDT', displayName: 'USDT.arb', ...token('usdt'), chainBadgePath: arbChain },
+  ArbUsdc: {
+    symbol: 'USDC',
+    displayName: 'USDC (ARB)',
+    ...token('usdc'),
+    chainBadgePath: arbChain,
+  },
+  ArbUsdt: {
+    symbol: 'USDT',
+    displayName: 'USDT (ARB)',
+    ...token('usdt'),
+    chainBadgePath: arbChain,
+  },
   Btc: {
     symbol: 'BTC',
     displayName: 'BTC',
@@ -37,16 +47,41 @@ export const ASSET_REGISTRY: InternalAssetMap<AssetMeta> = {
   Eth: { symbol: 'ETH', displayName: 'ETH', ...token('eth') },
   Flip: { symbol: 'FLIP', displayName: 'FLIP', ...token('flip') },
   HubDot: { symbol: 'DOT', displayName: 'DOT', ...token('dot') },
-  HubUsdc: { symbol: 'USDC', displayName: 'USDC.hub', ...token('usdc'), chainBadgePath: assChain },
-  HubUsdt: { symbol: 'USDT', displayName: 'USDT.hub', ...token('usdt'), chainBadgePath: assChain },
+  HubUsdc: {
+    symbol: 'USDC',
+    displayName: 'USDC (HUB)',
+    ...token('usdc'),
+    chainBadgePath: assChain,
+  },
+  HubUsdt: {
+    symbol: 'USDT',
+    displayName: 'USDT (HUB)',
+    ...token('usdt'),
+    chainBadgePath: assChain,
+  },
   Sol: { symbol: 'SOL', displayName: 'SOL', ...token('sol') },
-  SolUsdc: { symbol: 'USDC', displayName: 'USDC.sol', ...token('usdc'), chainBadgePath: solChain },
-  SolUsdt: { symbol: 'USDT', displayName: 'USDT.sol', ...token('usdt'), chainBadgePath: solChain },
-  Usdc: { symbol: 'USDC', displayName: 'USDC.eth', ...token('usdc'), chainBadgePath: ethChain },
-  Usdt: { symbol: 'USDT', displayName: 'USDT.eth', ...token('usdt'), chainBadgePath: ethChain },
+  SolUsdc: {
+    symbol: 'USDC',
+    displayName: 'USDC (SOL)',
+    ...token('usdc'),
+    chainBadgePath: solChain,
+  },
+  SolUsdt: {
+    symbol: 'USDT',
+    displayName: 'USDT (SOL)',
+    ...token('usdt'),
+    chainBadgePath: solChain,
+  },
+  Usdc: { symbol: 'USDC', displayName: 'USDC (ETH)', ...token('usdc'), chainBadgePath: ethChain },
+  Usdt: { symbol: 'USDT', displayName: 'USDT (ETH)', ...token('usdt'), chainBadgePath: ethChain },
   Wbtc: { symbol: 'WBTC', displayName: 'WBTC', ...token('wbtc') },
   Trx: { symbol: 'TRX', displayName: 'TRX', ...token('trx') },
-  TrxUsdt: { symbol: 'USDT', displayName: 'USDT.trx', ...token('usdt'), chainBadgePath: tronChain },
+  TrxUsdt: {
+    symbol: 'USDT',
+    displayName: 'USDT (TRON)',
+    ...token('usdt'),
+    chainBadgePath: tronChain,
+  },
 };
 
 const dataUrlCache = new Map<string, Promise<string>>();


### PR DESCRIPTION
## Summary

Tidies how a stablecoin's chain is shown in the **post copy** (X / Discord / Telegram), replacing the lowercase dot-suffix with a clearer parenthetical label.

| Before | After |
|--------|-------|
| `USDT.trx` | `USDT (TRON)` |
| `USDC.eth` / `USDT.eth` | `USDC (ETH)` / `USDT (ETH)` |
| `USDC.arb` / `USDT.arb` | `USDC (ARB)` / `USDT (ARB)` |
| `USDC.sol` / `USDT.sol` | `USDC (SOL)` / `USDT (SOL)` |
| `USDC.hub` / `USDT.hub` | `USDC (HUB)` / `USDT (HUB)` |

Tron is spelled out (`TRON`) since the `TRX` ticker is less recognizable to a general audience; the others keep their familiar 3-letter codes. The parens also remove the ambiguity a bare prefix would create (e.g. `TRX USDT` reads like a trading pair).

Example copy:
- `182.5K USDT (TRON) → 3.01 BTC at -0.12% vs market.`
- `172K USDC (ETH) → 171.02K USDT (ETH) at -0.01% vs market.`

## Scope

- **Copy only.** This changes the `displayName` field in `assetRegistry.ts`, which feeds `formatDiscordMessage`. The **banner image is unaffected** — it renders the bare `symbol` (`USDT`) plus the chain badge.
- Native assets (BTC, ETH, SOL, FLIP, DOT, TRX, WBTC) are unchanged — only multi-chain stablecoins carry a chain label.

## Testing

- Full suite passes (164 tests).
- Verified rendered copy locally for TRON / ETH / ARB swaps.