### PR TITLE
fix: disable Telegram link previews by default

### DIFF
--- a/src/channels/__tests__/telegram.test.tsx
+++ b/src/channels/__tests__/telegram.test.tsx
@@ -25,6 +25,9 @@ describe('sendMessage', () => {
         "https://api.telegram.org/bot1234/sendMessage",
         {
           "chat_id": "5678",
+          "link_preview_options": {
+            "is_disabled": true,
+          },
           "parse_mode": "HTML",
           "text": "hello <strong>bold</strong>",
         },

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -8,7 +8,7 @@ export type TelegramConfig = {
 export const sendMessage = async (
   { token, channelId }: TelegramConfig,
   text: string,
-  disablePreview?: boolean,
+  disablePreview = true,
 ) => {
   const url = `https://api.telegram.org/bot${token}/sendMessage`;
 

--- a/src/queues/__tests__/sendMessage.test.ts
+++ b/src/queues/__tests__/sendMessage.test.ts
@@ -20,6 +20,9 @@ describe('sendMessage', () => {
         "https://api.telegram.org/botbot token/sendMessage",
         {
           "chat_id": "123",
+          "link_preview_options": {
+            "is_disabled": true,
+          },
           "parse_mode": "HTML",
           "text": "Hello, world!",
         },


### PR DESCRIPTION
## Summary

Every message the bot sends contains explorer links, and Telegram was unfurling them into a redundant preview card beneath each post (WEB-3630).

Fix: default the `disablePreview` argument to `true` in the Telegram sender. Since no queue passes the argument, previews are now disabled for **all** message types. The parameter and the `opts` plumbing (`messageRouter` → `sendMessage`) are kept intact, so a caller can still override it from above (`opts: { disablePreview: false }`) if a preview is ever wanted.

## Change

- `src/channels/telegram.ts` — `disablePreview` now defaults to `true` (one line).
- Two snapshots updated to reflect the disabled preview in the Telegram request body.

## Testing

- Full suite passes (164 tests).

Closes WEB-3630.