### PR TITLE
fix: skip boost loan updates on X

### DIFF
--- a/src/queues/__tests__/newLoanUpdateCheck.test.ts
+++ b/src/queues/__tests__/newLoanUpdateCheck.test.ts
@@ -138,7 +138,7 @@ describe('newLoanUpdateCheck', () => {
       `);
     });
 
-    it('marks boost loan updates with isBoost so channels can filter them', async () => {
+    it('marks boost loan updates with isBoost and excludes them from twitter', async () => {
       vi.mocked(lpClient.request).mockResolvedValueOnce(mockGetNewBoostLoanUpdateResponse(11));
 
       const dispatchJobs = vi.fn();
@@ -147,10 +147,11 @@ describe('newLoanUpdateCheck', () => {
 
       const dispatched = dispatchJobs.mock.calls[0][0] as {
         name: string;
-        data: { filterData: unknown; message: string };
+        data: { platform: string; filterData: unknown; message: string };
       }[];
       const messageJobs = dispatched.filter((j) => j.name === 'messageRouter');
-      expect(messageJobs).toHaveLength(3);
+      // boost loans post to telegram + discord but are skipped on twitter (X)
+      expect(messageJobs.map((j) => j.data.platform)).toEqual(['telegram', 'discord']);
       messageJobs.forEach((j) => {
         expect(j.data.filterData).toMatchObject({ name: 'NEW_BORROW', isBoost: true });
         expect(j.data.message).toContain('Boost');

--- a/src/queues/newLoanUpdateCheck.tsx
+++ b/src/queues/newLoanUpdateCheck.tsx
@@ -72,49 +72,51 @@ const buildMessages = ({
   const filterName = type === 'BORROWING' ? 'NEW_BORROW' : 'NEW_REPAYMENT';
   const isBoost = isNullish(borrowerIdSs58);
 
-  return platforms.map((platform) => ({
-    name: 'messageRouter' as const,
-    data: {
-      platform,
-      message: renderForPlatform(
+  return platforms
+    .filter((platform) => !(isBoost && platform === 'twitter'))
+    .map((platform) => ({
+      name: 'messageRouter' as const,
+      data: {
         platform,
-        <>
-          <Line>
-            🏦 Loan{' '}
-            <Bold>
-              <ExplorerLink path={`/loans/${loanId}`} prefer="link">
-                #{loanId.toString()}
-              </ExplorerLink>
-            </Bold>
-          </Line>
-          <Line>
-            👤 Borrower:{' '}
-            <Bold>
-              {borrowerIdSs58 ? (
-                <ExplorerLink path={`/lps/${borrowerIdSs58}`} prefer="link">
-                  {abbreviate(borrowerIdSs58, 8)}
+        message: renderForPlatform(
+          platform,
+          <>
+            <Line>
+              🏦 Loan{' '}
+              <Bold>
+                <ExplorerLink path={`/loans/${loanId}`} prefer="link">
+                  #{loanId.toString()}
                 </ExplorerLink>
-              ) : (
-                'Boost'
-              )}
-            </Bold>
-          </Line>
-          <Line>
-            💳 Type: <Bold>{typeValue}</Bold>
-          </Line>
-          <Line>
-            📥 Amount:{' '}
-            <Bold>
-              <TokenAmount amount={amount} asset={asset} />
-            </Bold>
-            <UsdValue amount={amountValueUsd} />
-          </Line>
-          <Trailer />
-        </>,
-      ).trimEnd(),
-      filterData: { name: filterName, usdValue: amountValueUsd.toNumber(), isBoost },
-    },
-  }));
+              </Bold>
+            </Line>
+            <Line>
+              👤 Borrower:{' '}
+              <Bold>
+                {borrowerIdSs58 ? (
+                  <ExplorerLink path={`/lps/${borrowerIdSs58}`} prefer="link">
+                    {abbreviate(borrowerIdSs58, 8)}
+                  </ExplorerLink>
+                ) : (
+                  'Boost'
+                )}
+              </Bold>
+            </Line>
+            <Line>
+              💳 Type: <Bold>{typeValue}</Bold>
+            </Line>
+            <Line>
+              📥 Amount:{' '}
+              <Bold>
+                <TokenAmount amount={amount} asset={asset} />
+              </Bold>
+              <UsdValue amount={amountValueUsd} />
+            </Line>
+            <Trailer />
+          </>,
+        ).trimEnd(),
+        filterData: { name: filterName, usdValue: amountValueUsd.toNumber(), isBoost },
+      },
+    }));
 };
 
 const processJob: JobProcessor<Name> = (dispatchJobs) => async (job) => {


### PR DESCRIPTION
## Summary

Boost loan notifications ("Borrower: Boost" — borrower is the Boost system, no LP account) are noisy on the public X feed and add to X API cost. This skips them on **twitter only**; they still post to Discord and Telegram.

Mirrors the existing internal-swap X-skip in `swapStatusCheck` — filter the platform list before mapping:

```ts
return platforms
  .filter((platform) => !(isBoost && platform === 'twitter'))
  .map(...)
```

`isBoost` is already computed and carried in `filterData`, so no new plumbing.

## Note on the diff size

`newLoanUpdateCheck.tsx` shows ~80 changed lines, but almost all of it is **whitespace** — wrapping the existing `.map()` in `.filter().map()` re-indents the JSX body by two spaces. The only logic change is the added `.filter(...)` line.

## Alternative considered

The config layer already supports `excludeBoost: true` per channel (`config.ts`), which is the "cleaner" way — but that lives in the deployed `CONFIG` env var, which isn't accessible via a code PR. This achieves the same X-only result at the code level. Happy to switch to the config approach instead if preferred.

## Testing

- Full suite passes (174 tests); the boost-loan test now asserts telegram + discord only (no twitter).