### PR TITLE
feat: tag Portal and MakePay in swap posts

### DIFF
--- a/src/banners/discordMessage.ts
+++ b/src/banners/discordMessage.ts
@@ -14,6 +14,7 @@ const BROKER_HANDLES: Record<string, string | null> = {
   THORWallet: '@Thorwallet',
   THORSwap: '@THORSwap',
   SwapSpace: '@swapspaceco',
+  Portal: '@portalbridge_',
 };
 
 const INTEGRATOR_HANDLES: Record<string, string | null> = {
@@ -41,6 +42,7 @@ const INTEGRATOR_HANDLES: Record<string, string | null> = {
   BCDC: null,
   'Rango Direct': '@rangoexchange',
   'THORSwap UI': '@THORSwap',
+  MakePay: '@MakePayio',
 };
 
 // Resolves an alias to a display string. Returns null only for empty / 'unknown'.


### PR DESCRIPTION
## Summary

Adds two integrator/broker handle mappings so their swaps render with an `@handle` in the post copy:

- **Portal** → `@portalbridge_` (broker map — aliased `Portal` in the explorer)
- **MakePay** → `@MakePayio` (integrator map — aliased `MakePay` in the explorer)

## Rendered output (verified)

- Portal broker: `… via @portalbridge_.`
- MakePay affiliate: `… via @MakePayio.`
- MakePay via Portal: `… via @MakePayio, routed through @portalbridge_.`

## Notes

- Placement follows role: Portal is a broker account, MakePay an integrator/affiliate. If MakePay ever shows up as the broker on a swap, it'd need moving/adding to the broker map — easy follow-up.
- `formatDiscordMessage` feeds both X and Discord captions, so this applies to both.

## Testing

Full suite passes (174 tests).