### PR TITLE
feat: thousands separators in swap post amounts

### DIFF
--- a/src/banners/discordMessage.ts
+++ b/src/banners/discordMessage.ts
@@ -65,6 +65,9 @@ const STABLES = new Set(['USDC', 'USDT']);
 const stripTrailingZeros = (s: string): string =>
   s.includes('.') ? s.replace(/0+$/, '').replace(/\.$/, '') : s;
 
+const withThousands = (n: number, maxDecimals: number): string =>
+  new Intl.NumberFormat('en-US', { maximumFractionDigits: maxDecimals }).format(n);
+
 const formatAmount = (asset: ChainflipAsset, amount: number): string => {
   const meta = ASSET_REGISTRY[asset];
   const display = meta.displayName;
@@ -76,12 +79,10 @@ const formatAmount = (asset: ChainflipAsset, amount: number): string => {
     if (amount >= 1_000) {
       return `${stripTrailingZeros((amount / 1_000).toFixed(2))}K ${display}`;
     }
-    return `${Math.round(amount)} ${display}`;
+    return `${withThousands(amount, 0)} ${display}`;
   }
 
-  const num =
-    amount >= 100 ? stripTrailingZeros(amount.toFixed(1)) : stripTrailingZeros(amount.toFixed(2));
-  return `${num} ${display}`;
+  return `${withThousands(amount, amount >= 100 ? 1 : 2)} ${display}`;
 };
 
 const formatUsdCopy = (value: number): string => {


### PR DESCRIPTION
## Summary

Adds thousands separators to amounts in the swap post copy, matching the comma style already used in the lending/borrowing posts.

- Non-stablecoin amounts (and sub-1000 stables) now format with commas: `1,850 BNB`, `1,250,000 FLIP` — previously `1850 BNB`.
- Large stablecoin amounts keep their `K`/`M` abbreviation (`600K USDT`, `1.28M USDT (ETH)`) — the established banner-copy style.

## Before → after

| | Before | After |
|--|--------|-------|
| Non-stable | `1850 BNB` | `1,850 BNB` |
| Big non-stable | `1250000 FLIP` | `1,250,000 FLIP` |
| Small non-stable | `9.63 BTC` | `9.63 BTC` (unchanged) |
| Stable | `600K USDT` | `600K USDT` (unchanged) |

Implemented via `Intl.NumberFormat`, which also handles trailing-zero stripping.

## Testing

Full suite passes (174 tests).